### PR TITLE
Replace deprecated pad_left with pad_start 

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -13,7 +13,7 @@ repository = { type = "github", user = "titouancreach", repo = "gluid" }
 # https://gleam.run/writing-gleam/gleam-toml/.
 
 [dependencies]
-gleam_stdlib = "~> 0.34 or ~> 1.0"
+gleam_stdlib = "~> 0.42 or ~> 1.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,10 +2,10 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
+  { name = "gleam_stdlib", version = "0.57.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86EFACDF6460B8681E82752C5490F9630EC0F138F88A037DDCB241799AA8811F" },
+  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
 ]
 
 [requirements]
-gleam_stdlib = { version = "~> 0.34 or ~> 1.0" }
+gleam_stdlib = { version = "~> 0.42 or ~> 1.0" }
 gleeunit = { version = "~> 1.0" }

--- a/src/gluid.gleam
+++ b/src/gluid.gleam
@@ -1,5 +1,4 @@
 import gleam/int
-import gleam/io
 import gleam/string
 
 fn split_to_chunks(src: String, chunk_size: Int) -> List(String) {
@@ -13,13 +12,6 @@ fn split_to_chunks(src: String, chunk_size: Int) -> List(String) {
   }
 }
 
-fn binary_pprint(src: Int) -> String {
-  src
-  |> int.to_base2
-  |> string.pad_start(32, "0")
-  |> split_to_chunks(4)
-  |> string.join(" ")
-}
 
 fn format_uuid(src: String) -> String {
   string.slice(src, 0, 8)

--- a/src/gluid.gleam
+++ b/src/gluid.gleam
@@ -1,5 +1,5 @@
-import gleam/io
 import gleam/int
+import gleam/io
 import gleam/string
 
 fn split_to_chunks(src: String, chunk_size: Int) -> List(String) {
@@ -16,7 +16,7 @@ fn split_to_chunks(src: String, chunk_size: Int) -> List(String) {
 fn binary_pprint(src: Int) -> String {
   src
   |> int.to_base2
-  |> string.pad_left(32, "0")
+  |> string.pad_start(32, "0")
   |> split_to_chunks(4)
   |> string.join(" ")
 }
@@ -52,29 +52,29 @@ pub fn guidv4() -> String {
   // - the 7th byte is the 3rd byte of B
   // - the 9th byte is the 1st byte of C
 
-    let a =
+  let a =
     int.random(0xFF_FF_FF_FF)
     |> int.to_base16
-    |> string.pad_left(8, "0")
+    |> string.pad_start(8, "0")
 
-    let b =
+  let b =
     int.random(0xFF_FF_FF_FF)
     |> int.bitwise_and(0xFF_FF_0F_FF)
     |> int.bitwise_or(0x00_00_40_00)
     |> int.to_base16
-    |> string.pad_left(8, "0")
+    |> string.pad_start(8, "0")
 
-    let c =
+  let c =
     int.random(0xFF_FF_FF_FF)
     |> int.bitwise_and(0x3F_FF_FF_FF)
     |> int.bitwise_or(0x80_00_00_00)
     |> int.to_base16
-    |> string.pad_left(8, "0")
+    |> string.pad_start(8, "0")
 
-    let d =
+  let d =
     int.random(0xFF_FF_FF_FF)
     |> int.to_base16
-    |> string.pad_left(8, "0")
+    |> string.pad_start(8, "0")
 
   let concatened = a <> b <> c <> d
 


### PR DESCRIPTION
I wanted to use this library with gleam stdlib 0.57, but it failed to build with the message that pad_left had been deprecated. I am submitting this PR, bumping the minimum version, replacing the calls and removing a seemingly unused method. 